### PR TITLE
Fix #30 Remove debian/ubuntu support

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -19,7 +19,3 @@ supports          'amazon'
 supports          'oracle'
 supports          'redhat'
 supports          'scientific'
-
-# platform_family?('debian'): not tested, but may work
-supports          'debian'
-supports          'ubuntu'


### PR DESCRIPTION
- this cookbook creates rhel-specific rpms and does not apply to
  debian/ubuntu
